### PR TITLE
fix: No more "missing act" warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@testing-library/jest-dom": "5.16.4",
-    "@testing-library/react": "13.3.0",
+    "@testing-library/react": "https://pkg.csb.dev/testing-library/react-testing-library/commit/bfd1db76/@testing-library/react",
     "@testing-library/react-hooks": "8.0.1",
     "react": "18.0.0",
     "react-dom": "18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1689,10 +1689,9 @@
     "@babel/runtime" "^7.12.5"
     react-error-boundary "^3.1.0"
 
-"@testing-library/react@13.3.0":
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.3.0.tgz#bf298bfbc5589326bbcc8052b211f3bb097a97c5"
-  integrity sha512-DB79aA426+deFgGSjnf5grczDPiL4taK3hFaa+M5q7q20Kcve9eQottOG5kZ74KEr55v0tU2CQormSSDK87zYQ==
+"@testing-library/react@https://pkg.csb.dev/testing-library/react-testing-library/commit/bfd1db76/@testing-library/react":
+  version "0.0.0-semantically-released"
+  resolved "https://pkg.csb.dev/testing-library/react-testing-library/commit/bfd1db76/@testing-library/react#ce282351bee0406e4db400d6508e82d098c0965e"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.5.0"


### PR DESCRIPTION
Testing https://github.com/testing-library/react-testing-library/pull/1137